### PR TITLE
Use inferred errorsets

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -104,11 +104,11 @@ pub const Texture = struct {
 ```
 * Creates a texture from png file
 ```zig
-pub fn createFromPNG(path: []const  u8) Error!Texture
+pub fn createFromPNG(path: []const  u8) !Texture
 ```
 * Creates a texture from png memory
 ```zig
-pub fn createFromPNGMemory(mem: []const  u8) Error!Texture
+pub fn createFromPNGMemory(mem: []const  u8) !Texture
 ```
 * Creates a texture from given colour
 ```zig
@@ -136,15 +136,15 @@ pub fn init(updatefn: ?fn (deltatime: f32) anyerror!void, fixedupdatefn: ?fn (fi
 
 * Deinitializes the engine
 ```zig
-pub fn deinit() Error!void
+pub fn deinit() !void
 ```
 * Opens the window
 ```zig 
-pub fn open() Error!void
+pub fn open() !void
  ```
  * Closes the window
 ```zig 
-pub fn close() Error!void
+pub fn close() !void
  ```
  * Updates the engine
  ```zig 
@@ -248,7 +248,7 @@ pub fn ParticleSystemGeneric(maxparticle_count: u32) type {
         list: [maxparticle]Particle = undefined,
 
         /// Draw function for drawing particle
-        drawfn: ?fn (self: Particle) Error!void = null
+        drawfn: ?fn (self: Particle) !void = null
 		
 		// functions ..
 	};
@@ -268,19 +268,19 @@ pub fn draw(self: *Self) !void
 ```
 * Draws the particles as rectangles
 ```zig
-pub fn drawAsRectangles(self: Self) Error!void 
+pub fn drawAsRectangles(self: Self) !void 
 ```
 * Draws the particles as triangles
 ```zig
-pub fn drawAsTriangles(self: Self) Error!void 
+pub fn drawAsTriangles(self: Self) !void 
 ```
 * Draws the particles as circles
 ```zig
-pub fn drawAsCircles(self: Self) Error!void 
+pub fn drawAsCircles(self: Self) !void 
 ```
 * Draws the particles as textures
 ```zig
-pub fn drawAsTextures(self: Self) Error!void 
+pub fn drawAsTextures(self: Self) !void 
 ```
 * Updates the particles 
 ```zig
@@ -335,11 +335,11 @@ pub fn disableTextureBatch2D() void
 ```
 * Returns the enabled texture
 ```zig
-pub fn getTextureBatch2D() Error!Texture
+pub fn getTextureBatch2D() !Texture
 ```
 * Enables the custom batch
 ```zig
-pub fn enableCustomBatch2D(comptime batchtype: type, batch: *batchtype, shader: u32) Error!void 
+pub fn enableCustomBatch2D(comptime batchtype: type, batch: *batchtype, shader: u32) !void 
 ```
 * Disables the custom batch
 ```zig
@@ -347,33 +347,33 @@ pub fn disableCustomBatch2D(comptime batchtype: type) void
 ```
 * Returns the current batch
 ```zig
-pub fn getCustomBatch2D(comptime batchtype: type) Error!*batchtype 
+pub fn getCustomBatch2D(comptime batchtype: type) !*batchtype 
 ```
 * Pushes the batch
 ```zig
-pub fn pushBatch2D(tag: Renderer2DBatchTag) Error!void 
+pub fn pushBatch2D(tag: Renderer2DBatchTag) !void 
 ```
 * Pops the batch
 ```zig
-pub fn popBatch2D() Error!void 
+pub fn popBatch2D() !void 
 ```
 * Flushes the batch
 ```zig
-pub fn flushBatch2D() Error!void 
+pub fn flushBatch2D() !void 
 ```
 * Draws a pixel
 ```zig
-pub fn drawPixel(pixel: Vec2f, colour: Colour) Error!void 
+pub fn drawPixel(pixel: Vec2f, colour: Colour) !void 
 ```
 
 * Draws a line
 ```zig
-pub fn drawLine(line0: Vec2f, line1: Vec2f, colour: Colour) Error!void 
+pub fn drawLine(line0: Vec2f, line1: Vec2f, colour: Colour) !void 
 ```
 
 * Draws a triangle
 ```zig
-pub fn drawTriangle(left: Vec2f, top: Vec2f, right: Vec2f, colour: Colour) Error!void 
+pub fn drawTriangle(left: Vec2f, top: Vec2f, right: Vec2f, colour: Colour) !void 
 ```
 
 * Draws a circle
@@ -381,47 +381,47 @@ pub fn drawTriangle(left: Vec2f, top: Vec2f, right: Vec2f, colour: Colour) Error
 --> The segments are lowered for sake of making it smaller on the batch
 
 ```zig
-pub fn drawCircle(position: Vec2f, radius: f32, colour: Colour) Error!void 
+pub fn drawCircle(position: Vec2f, radius: f32, colour: Colour) !void 
 ```
 
 * Draws a circle
 ```zig
-pub fn drawCircleAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle: i32, segments: i32, colour: Colour) Error!void 
+pub fn drawCircleAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle: i32, segments: i32, colour: Colour) !void 
 ```
 * Draws a circle line
 
 --> The segments are lowered for sake of making it smaller on the batch
 
 ```zig
-pub fn drawCircleLines(position: Vec2f, radius: f32, colour: Colour) Error!void 
+pub fn drawCircleLines(position: Vec2f, radius: f32, colour: Colour) !void 
 ```
 
 * Draws a circle lines
 ```zig
-pub fn drawCircleLinesAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle: i32, segments: i32, colour: Colour) Error!void 
+pub fn drawCircleLinesAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle: i32, segments: i32, colour: Colour) !void 
 ```
 
 * Draws a rectangle
 ```zig
-pub fn drawRectangle(rect: Rectangle, colour: Colour) Error!void 
+pub fn drawRectangle(rect: Rectangle, colour: Colour) !void 
 ```
 
 * Draws a rectangle lines
 ```zig
-pub fn drawRectangleLines(rect: Rectangle, colour: Colour) Error!void 
+pub fn drawRectangleLines(rect: Rectangle, colour: Colour) !void 
 ```
 
 * Draws a rectangle rotated(rotation should be provided in radians)
 ```zig
-pub fn drawRectangleRotated(rect: Rectangle, origin: Vec2f, rotation: f32, colour: Colour) Error!void 
+pub fn drawRectangleRotated(rect: Rectangle, origin: Vec2f, rotation: f32, colour: Colour) !void 
 ```
 
 * Draws a texture
 ```zig
-pub fn drawTexture(rect: Rectangle, srcrect: Rectangle, colour: Colour) Error!void 
+pub fn drawTexture(rect: Rectangle, srcrect: Rectangle, colour: Colour) !void 
 ```
 
 * Draws a texture(rotation should be provided in radians)
 ```zig
-pub fn drawTextureRotated(rect: Rectangle, srcrect: Rectangle, origin: Vec2f, rotation: f32, colour: Colour) Error!void 
+pub fn drawTextureRotated(rect: Rectangle, srcrect: Rectangle, origin: Vec2f, rotation: f32, colour: Colour) !void 
 ```

--- a/examples/particlesystem.zig
+++ b/examples/particlesystem.zig
@@ -15,7 +15,7 @@ var particlesys = ParticleSystem{
     .drawfn = particledraw,
 };
 
-fn particledraw(self: engine.Particle) engine.Error!void {
+fn particledraw(self: engine.Particle) !void {
     const rect = engine.Rectangle{
         .x = self.position.x,
         .y = self.position.y,

--- a/examples/primitive-renderer.zig
+++ b/examples/primitive-renderer.zig
@@ -57,7 +57,7 @@ fn shaderAttribs() void {
     kira_gl.shaderProgramSetVertexAttribPointer(1, 4, f32, false, stride, @intToPtr(?*const c_void, @byteOffsetOf(Vertex, "colour")));
 }
 
-fn submitFn(self: *Batch, vertex: [Batch.max_vertex_count]Vertex) kira_renderer.Error!void {
+fn submitFn(self: *Batch, vertex: [Batch.max_vertex_count]Vertex) !void {
     try self.submitVertex(self.submission_counter, 0, vertex[0]);
     try self.submitVertex(self.submission_counter, 1, vertex[1]);
     try self.submitVertex(self.submission_counter, 2, vertex[2]);

--- a/examples/primitive-window.zig
+++ b/examples/primitive-window.zig
@@ -47,7 +47,7 @@ pub fn main() !void {
     defer window.destroy() catch unreachable;
 
     input.bindKey('A') catch |err| {
-        if (err == kira_input.Error.NoEmptyBinding) {
+        if (err == error.NoEmptyBinding) {
             input.clearAllBindings();
             try input.bindKey('A');
         } else return err;

--- a/examples/simpleshooter.zig
+++ b/examples/simpleshooter.zig
@@ -114,7 +114,7 @@ fn update(deltatime: f32) !void {
                 std.log.notice("player: fire({})", .{player.firecount});
 
                 playerbulletfactory.add(bullet) catch |err| {
-                    if (err == engine.Error.CheckFailed) {
+                    if (err == error.CheckFailed) {
                         player.firecount += 1;
                     }
                 };

--- a/examples/simpleshooteradvanced.zig
+++ b/examples/simpleshooteradvanced.zig
@@ -153,7 +153,7 @@ fn shaderAttribs() void {
     gl.shaderProgramSetVertexAttribPointer(1, 4, f32, false, stride, @intToPtr(?*const c_void, @byteOffsetOf(Vertex, "colour")));
 }
 
-fn submitFn(self: *Batch, vertex: [Batch.max_vertex_count]Vertex) renderer.Error!void {
+fn submitFn(self: *Batch, vertex: [Batch.max_vertex_count]Vertex) !void {
     try self.submitVertex(self.submission_counter, 0, vertex[0]);
     try self.submitVertex(self.submission_counter, 1, vertex[1]);
     try self.submitVertex(self.submission_counter, 2, vertex[2]);
@@ -204,7 +204,7 @@ pub fn main() !void {
     defer win.destroy() catch unreachable;
 
     inp.bindKey('A') catch |err| {
-        if (err == input.Error.NoEmptyBinding) {
+        if (err == error.NoEmptyBinding) {
             inp.clearAllBindings();
             try inp.bindKey('A');
         } else return err;
@@ -279,7 +279,7 @@ pub fn main() !void {
                     player.firecount -= 1;
                     std.log.notice("player: fire({})", .{player.firecount});
                     playerbulletfactory.add(bullet) catch |err| {
-                        if (err == utils.Error.CheckFailed) {
+                        if (err == error.CheckFailed) {
                             player.firecount += 1;
                         }
                     };

--- a/src/kiragine/core.zig
+++ b/src/kiragine/core.zig
@@ -79,7 +79,7 @@ var allocator: *std.mem.Allocator = undefined;
 
 /// Initializes the engine
 pub fn init(updatefn: ?fn (deltatime: f32) anyerror!void, fixedupdatefn: ?fn (fixedtime: f32) anyerror!void, draw2dfn: ?fn () anyerror!void, width: i32, height: i32, title: []const u8, fpslimit: u32, alloc: *std.mem.Allocator) !void {
-    if (pengineready) return Error.EngineIsInitialized;
+    if (pengineready) return error.EngineIsInitialized;
 
     allocator = alloc;
 
@@ -134,8 +134,8 @@ pub fn init(updatefn: ?fn (deltatime: f32) anyerror!void, fixedupdatefn: ?fn (fi
 }
 
 /// Deinitializes the engine
-pub fn deinit() Error!void {
-    if (!pengineready) return Error.EngineIsNotInitialized;
+pub fn deinit() !void {
+    if (!pengineready) return error.EngineIsNotInitialized;
 
     deinitRenderer();
 
@@ -150,20 +150,20 @@ pub fn deinit() Error!void {
 }
 
 /// Opens the window 
-pub fn open() Error!void {
-    if (!pengineready) return Error.EngineIsNotInitialized;
+pub fn open() !void {
+    if (!pengineready) return error.EngineIsNotInitialized;
     pwinrun = true;
 }
 
 /// Closes the window 
-pub fn close() Error!void {
-    if (!pengineready) return Error.EngineIsNotInitialized;
+pub fn close() !void {
+    if (!pengineready) return error.EngineIsNotInitialized;
     pwinrun = false;
 }
 
 /// Updates the engine
 pub fn update() !void {
-    if (!pengineready) return Error.EngineIsNotInitialized;
+    if (!pengineready) return error.EngineIsNotInitialized;
 
     // Source: https://gafferongames.com/post/fix_your_timestep/
     var last: f64 = getElapsedTime();

--- a/src/kiragine/kira/glfw.zig
+++ b/src/kiragine/kira/glfw.zig
@@ -25,17 +25,14 @@ const c = @import("c.zig");
 const std = @import("std");
 usingnamespace @import("log.zig");
 
-/// Error set
-pub const Error = error{GLFWFailedToInitialize};
-
 fn errorCallback(err: i32, desc: [*c]const u8) callconv(.C) void {
     std.log.emerg("GLFW -> {}:{*}", .{ err, desc });
 }
 
 /// Initializes glfw
-pub fn init() Error!void {
+pub fn init() !void {
     _ = c.glfwSetErrorCallback(errorCallback);
-    if (c.glfwInit() == 0) return Error.GLFWFailedToInitialize;
+    if (c.glfwInit() == 0) return error.GLFWFailedToInitialize;
 }
 
 /// Deinitializes glfw

--- a/src/kiragine/kira/input.zig
+++ b/src/kiragine/kira/input.zig
@@ -24,9 +24,6 @@
 const c = @import("c.zig");
 const utils = @import("utils.zig");
 
-/// Error set
-pub const Error = error{ InvalidBinding, NoEmptyBinding };
-
 /// Input info
 pub const Info = struct {
     /// States
@@ -78,7 +75,7 @@ pub const Info = struct {
     }
 
     /// Binds a key
-    pub fn bindKey(self: *Info, key: i16) Error!void {
+    pub fn bindKey(self: *Info, key: i16) !void {
         var i: u8 = 0;
         var l = &self.key_list;
         while (i < max_key_count) : (i += 1) {
@@ -90,11 +87,11 @@ pub const Info = struct {
                 return;
             }
         }
-        return Error.NoEmptyBinding;
+        return error.NoEmptyBinding;
     }
 
     /// Unbinds a key
-    pub fn unbindKey(self: *Info, key: i16) Error!void {
+    pub fn unbindKey(self: *Info, key: i16) !void {
         var i: u8 = 0;
         var l = &self.key_list;
         while (i < max_key_count) : (i += 1) {
@@ -103,11 +100,11 @@ pub const Info = struct {
                 return;
             }
         }
-        return Error.InvalidBinding;
+        return error.InvalidBinding;
     }
 
     /// Binds a mouse button
-    pub fn bindMButton(self: *Info, key: i16) Error!void {
+    pub fn bindMButton(self: *Info, key: i16) !void {
         var i: u8 = 0;
         var l = &self.mbutton_list;
         while (i < max_mbutton_count) : (i += 1) {
@@ -119,11 +116,11 @@ pub const Info = struct {
                 return;
             }
         }
-        return Error.NoEmptyBinding;
+        return error.NoEmptyBinding;
     }
 
     /// Unbinds a mouse button
-    pub fn unbindMButton(self: *Info, key: i16) Error!void {
+    pub fn unbindMButton(self: *Info, key: i16) !void {
         var i: u8 = 0;
         var l = &self.mbutton_list;
         while (i < max_mbutton_count) : (i += 1) {
@@ -132,11 +129,11 @@ pub const Info = struct {
                 return;
             }
         }
-        return Error.InvalidBinding;
+        return error.InvalidBinding;
     }
 
     /// Returns a binded key state
-    pub fn keyState(self: *Info, key: i16) Error!State {
+    pub fn keyState(self: *Info, key: i16) !State {
         var i: u8 = 0;
         var l = &self.key_list;
         while (i < max_key_count) : (i += 1) {
@@ -144,11 +141,11 @@ pub const Info = struct {
                 return l[i].status;
             }
         }
-        return Error.InvalidBinding;
+        return error.InvalidBinding;
     }
 
     /// Returns a const reference to a binded key state
-    pub fn keyStatePtr(self: *Info, key: i16) Error!*const State {
+    pub fn keyStatePtr(self: *Info, key: i16) !*const State {
         var i: u8 = 0;
         var l = &self.key_list;
         while (i < max_key_count) : (i += 1) {
@@ -156,11 +153,11 @@ pub const Info = struct {
                 return &l[i].status;
             }
         }
-        return Error.InvalidBinding;
+        return error.InvalidBinding;
     }
 
     /// Returns a binded key state
-    pub fn mbuttonState(self: *Info, key: i16) Error!State {
+    pub fn mbuttonState(self: *Info, key: i16) !State {
         var i: u8 = 0;
         var l = &self.mbutton_list;
         while (i < max_mbutton_count) : (i += 1) {
@@ -168,11 +165,11 @@ pub const Info = struct {
                 return l[i].status;
             }
         }
-        return Error.InvalidBinding;
+        return error.InvalidBinding;
     }
 
     /// Returns a const reference to a binded key state
-    pub fn mbuttonStatePtr(self: *Info, key: i16) Error!*const State {
+    pub fn mbuttonStatePtr(self: *Info, key: i16) !*const State {
         var i: u8 = 0;
         var l = &self.mbutton_list;
         while (i < max_mbutton_count) : (i += 1) {
@@ -180,7 +177,7 @@ pub const Info = struct {
                 return &l[i].status;
             }
         }
-        return Error.InvalidBinding;
+        return error.InvalidBinding;
     }
 
     /// Handles the inputs

--- a/src/kiragine/kira/utils.zig
+++ b/src/kiragine/kira/utils.zig
@@ -1,14 +1,12 @@
-/// Error set
-pub const Error = error{CheckFailed};
 const std = @import("std");
 usingnamespace @import("log.zig");
 
 // TODO: Localized cross-platform(win32-posix) timer
 
 /// If expresion is true return(CheckFailed) error
-pub fn check(expression: bool, comptime msg: []const u8, va: anytype) Error!void {
+pub fn check(expression: bool, comptime msg: []const u8, va: anytype) !void {
     if (expression) {
         std.log.emerg(msg, va);
-        return Error.CheckFailed;
+        return error.CheckFailed;
     }
 }

--- a/src/kiragine/renderer.zig
+++ b/src/kiragine/renderer.zig
@@ -124,7 +124,7 @@ pub fn ParticleSystemGeneric(maxparticle_count: u32) type {
         list: [maxparticle]Particle = undefined,
 
         /// Draw function for drawing particle
-        drawfn: ?fn (self: Particle) Error!void = null,
+        drawfn: ?fn (self: Particle) !void = null,
 
         /// Clear the all particles
         pub fn clearAll(self: *Self) void {
@@ -133,7 +133,7 @@ pub fn ParticleSystemGeneric(maxparticle_count: u32) type {
         }
 
         /// Draw the particles
-        pub fn draw(self: Self) Error!void {
+        pub fn draw(self: Self) !void {
             if (self.drawfn) |fun| {
                 var i: u32 = 0;
                 while (i < Self.maxparticle) : (i += 1) {
@@ -148,7 +148,7 @@ pub fn ParticleSystemGeneric(maxparticle_count: u32) type {
         }
 
         /// Draws the particles as rectangles
-        pub fn drawAsRectangles(self: Self) Error!void {
+        pub fn drawAsRectangles(self: Self) !void {
             var i: u32 = 0;
             while (i < Self.maxparticle) : (i += 1) {
                 if (self.list[i].is_alive) {
@@ -164,7 +164,7 @@ pub fn ParticleSystemGeneric(maxparticle_count: u32) type {
         }
         
         /// Draws the particles as triangles
-        pub fn drawAsTriangles(self: Self) Error!void {
+        pub fn drawAsTriangles(self: Self) !void {
             var i: u32 = 0;
             while (i < Self.maxparticle) : (i += 1) {
                 if (self.list[i].is_alive) {
@@ -179,7 +179,7 @@ pub fn ParticleSystemGeneric(maxparticle_count: u32) type {
         }
         
         /// Draws the particles as circles
-        pub fn drawAsCircles(self: Self) Error!void {
+        pub fn drawAsCircles(self: Self) !void {
             var i: u32 = 0;
             while (i < Self.maxparticle) : (i += 1) {
                 if (self.list[i].is_alive) {
@@ -191,7 +191,7 @@ pub fn ParticleSystemGeneric(maxparticle_count: u32) type {
         
         /// Draws the particles as textures
         /// Don't forget the enable texture batch!
-        pub fn drawAsTextures(self: Self) Error!void {
+        pub fn drawAsTextures(self: Self) !void {
             var i: u32 = 0;
             while (i < Self.maxparticle) : (i += 1) {
                 if (self.list[i].is_alive) {
@@ -396,18 +396,18 @@ pub fn disableTextureBatch2D() void {
 }
 
 /// Returns the enabled texture
-pub fn getTextureBatch2D() Error!Texture {
+pub fn getTextureBatch2D() !Texture {
     if (prenderer2D.textured) {
         return prenderer2D.current_texture;
     }
-    return Error.InvalidTexture;
+    return error.InvalidTexture;
 }
 
 /// Enables the custom batch
-pub fn enableCustomBatch2D(comptime batchtype: type, batch: *batchtype, shader: u32) Error!void {
+pub fn enableCustomBatch2D(comptime batchtype: type, batch: *batchtype, shader: u32) !void {
     if (batchtype == Batch2DQuadNoTexture) {
         if (prenderer2D.custombatch) {
-            return Error.UnableToEnableCustomBatch; 
+            return error.UnableToEnableCustomBatch; 
         }
         prenderer2D.custombatch = true;
         prenderer2D.current_quadbatch_notexture = batch;
@@ -415,7 +415,7 @@ pub fn enableCustomBatch2D(comptime batchtype: type, batch: *batchtype, shader: 
         return;
     } else if (batchtype == Batch2DQuadTexture) {
         if (prenderer2D.custombatch) {
-            return Error.UnableToEnableCustomBatch; 
+            return error.UnableToEnableCustomBatch; 
         }
         prenderer2D.custombatch = true;
         prenderer2D.current_quadbatch_texture = batch;
@@ -444,7 +444,7 @@ pub fn disableCustomBatch2D(comptime batchtype: type) void {
 }
 
 /// Returns the current batch 
-pub fn getCustomBatch2D(comptime batchtype: type) Error!*batchtype {
+pub fn getCustomBatch2D(comptime batchtype: type) !*batchtype {
     if (batchtype == Batch2DQuadNoTexture) {
         return &current_quadbatch_notexture;
     } else if (batchtype == Batch2DQuadTexture) {
@@ -455,20 +455,20 @@ pub fn getCustomBatch2D(comptime batchtype: type) Error!*batchtype {
 }
 
 /// Pushes the batch
-pub fn pushBatch2D(tag: Renderer2DBatchTag) Error!void {
+pub fn pushBatch2D(tag: Renderer2DBatchTag) !void {
     prenderer2D.tag = tag;
 
     switch (prenderer2D.tag) {
         Renderer2DBatchTag.pixels => {
-            if (prenderer2D.textured) return Error.InvalidBatch; // No textured lines
+            if (prenderer2D.textured) return error.InvalidBatch; // No textured lines
             prenderer2D.current_quadbatch_notexture.submitfn = pnoTextureSubmitQuadfn;
         },
         Renderer2DBatchTag.lines => {
-            if (prenderer2D.textured) return Error.InvalidBatch; // No textured lines
+            if (prenderer2D.textured) return error.InvalidBatch; // No textured lines
             prenderer2D.current_quadbatch_notexture.submitfn = pnoTextureSubmitQuadfn;
         },
         Renderer2DBatchTag.triangles => {
-            if (prenderer2D.textured) return Error.InvalidBatch; // No textured triangle
+            if (prenderer2D.textured) return error.InvalidBatch; // No textured triangle
             prenderer2D.current_quadbatch_notexture.submitfn = pnoTextureSubmitQuadfn;
         },
         Renderer2DBatchTag.quads => {
@@ -508,7 +508,7 @@ pub fn pushBatch2D(tag: Renderer2DBatchTag) Error!void {
 }
 
 /// Pops the batch
-pub fn popBatch2D() Error!void {
+pub fn popBatch2D() !void {
     defer {
         prenderer2D.cam.detach();
         if (prenderer2D.textured) {
@@ -525,21 +525,21 @@ pub fn popBatch2D() Error!void {
     switch (prenderer2D.tag) {
         Renderer2DBatchTag.pixels => {
             if (prenderer2D.textured) {
-                return Error.InvalidBatch;
+                return error.InvalidBatch;
             } else {
                 try prenderer2D.current_quadbatch_notexture.draw(gl.DrawMode.points);
             }
         },
         Renderer2DBatchTag.lines => {
             if (prenderer2D.textured) {
-                return Error.InvalidBatch;
+                return error.InvalidBatch;
             } else {
                 try prenderer2D.current_quadbatch_notexture.draw(gl.DrawMode.lines);
             }
         },
         Renderer2DBatchTag.triangles => {
             if (prenderer2D.textured) {
-                return Error.InvalidBatch;
+                return error.InvalidBatch;
             } else {
                 try prenderer2D.current_quadbatch_notexture.draw(gl.DrawMode.triangles);
             }
@@ -557,18 +557,18 @@ pub fn popBatch2D() Error!void {
 }
 
 /// Flushes the batch
-pub fn flushBatch2D() Error!void {
+pub fn flushBatch2D() !void {
     const tag = prenderer2D.tag;
     try popBatch2D();
     try pushBatch2D(tag);
 }
 
 /// Draws a pixel
-pub fn drawPixel(pixel: Vec2f, colour: Colour) Error!void {
-    if (prenderer2D.textured) return Error.InvalidBatch;
+pub fn drawPixel(pixel: Vec2f, colour: Colour) !void {
+    if (prenderer2D.textured) return error.InvalidBatch;
     switch (prenderer2D.tag) {
         Renderer2DBatchTag.quads, Renderer2DBatchTag.triangles, Renderer2DBatchTag.lines => {
-            return Error.InvalidBatch;
+            return error.InvalidBatch;
         },
         else => {},
     }
@@ -578,7 +578,7 @@ pub fn drawPixel(pixel: Vec2f, colour: Colour) Error!void {
         .{ .position = pixel, .colour = colour },
         .{ .position = pixel, .colour = colour },
     }) catch |err| {
-        if (err == renderer.Error.ObjectOverflow) {
+        if (err == error.ObjectOverflow) {
             if (prenderer2D.autoflush) {
                 try flushBatch2D();
                 try prenderer2D.current_quadbatch_notexture.submitDrawable([Batch2DQuadNoTexture.max_vertex_count]Vertex2DNoTexture{
@@ -588,18 +588,18 @@ pub fn drawPixel(pixel: Vec2f, colour: Colour) Error!void {
                     .{ .position = pixel, .colour = colour }
                 });
             } else {
-                return Error.FailedToDraw;
+                return error.FailedToDraw;
             }
         } else return err;
     };
 }
 
 /// Draws a line
-pub fn drawLine(line0: Vec2f, line1: Vec2f, colour: Colour) Error!void {
-    if (prenderer2D.textured) return Error.InvalidBatch;
+pub fn drawLine(line0: Vec2f, line1: Vec2f, colour: Colour) !void {
+    if (prenderer2D.textured) return error.InvalidBatch;
     switch (prenderer2D.tag) {
         Renderer2DBatchTag.quads, Renderer2DBatchTag.triangles => {
-            return Error.InvalidBatch;
+            return error.InvalidBatch;
         },
         else => {},
     }
@@ -609,7 +609,7 @@ pub fn drawLine(line0: Vec2f, line1: Vec2f, colour: Colour) Error!void {
         .{ .position = line1, .colour = colour },
         .{ .position = line1, .colour = colour },
     }) catch |err| {
-        if (err == renderer.Error.ObjectOverflow) {
+        if (err == error.ObjectOverflow) {
             if (prenderer2D.autoflush) {
                 try flushBatch2D();
                 try prenderer2D.current_quadbatch_notexture.submitDrawable([Batch2DQuadNoTexture.max_vertex_count]Vertex2DNoTexture{
@@ -619,18 +619,18 @@ pub fn drawLine(line0: Vec2f, line1: Vec2f, colour: Colour) Error!void {
                     .{ .position = line1, .colour = colour },
                 });
             } else {
-                return Error.FailedToDraw;
+                return error.FailedToDraw;
             }
         } else return err;
     };
 }
 
 /// Draws a triangle
-pub fn drawTriangle(left: Vec2f, top: Vec2f, right: Vec2f, colour: Colour) Error!void {
-    if (prenderer2D.textured) return Error.InvalidBatch;
+pub fn drawTriangle(left: Vec2f, top: Vec2f, right: Vec2f, colour: Colour) !void {
+    if (prenderer2D.textured) return error.InvalidBatch;
     switch (prenderer2D.tag) {
         Renderer2DBatchTag.lines => {
-            return Error.InvalidBatch;
+            return error.InvalidBatch;
         },
         else => {},
     }
@@ -640,7 +640,7 @@ pub fn drawTriangle(left: Vec2f, top: Vec2f, right: Vec2f, colour: Colour) Error
         .{ .position = right, .colour = colour },
         .{ .position = right, .colour = colour },
     }) catch |err| {
-        if (err == renderer.Error.ObjectOverflow) {
+        if (err == error.ObjectOverflow) {
             if (prenderer2D.autoflush) {
                 try flushBatch2D();
                 try prenderer2D.current_quadbatch_notexture.submitDrawable([Batch2DQuadNoTexture.max_vertex_count]Vertex2DNoTexture{
@@ -650,7 +650,7 @@ pub fn drawTriangle(left: Vec2f, top: Vec2f, right: Vec2f, colour: Colour) Error
                     .{ .position = right, .colour = colour },
                 });
             } else {
-                return Error.FailedToDraw;
+                return error.FailedToDraw;
             }
         } else return err;
     };
@@ -659,13 +659,13 @@ pub fn drawTriangle(left: Vec2f, top: Vec2f, right: Vec2f, colour: Colour) Error
 /// Draws a circle
 /// The segments are lowered for sake of 
 /// making it smaller on the batch
-pub fn drawCircle(position: Vec2f, radius: f32, colour: Colour) Error!void {
+pub fn drawCircle(position: Vec2f, radius: f32, colour: Colour) !void {
     try drawCircleAdvanced(position, radius, 0, 360, 16, colour);
 }
 
 // Source: https://github.com/raysan5/raylib/blob/f1ed8be5d7e2d966d577a3fd28e53447a398b3b6/src/shapes.c#L209
 /// Draws a circle
-pub fn drawCircleAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle: i32, segments: i32, colour: Colour) Error!void {
+pub fn drawCircleAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle: i32, segments: i32, colour: Colour) !void {
     const SMOOTH_CIRCLE_ERROR_RATE = comptime 0.5;
     
     var iradius = radius;
@@ -711,12 +711,12 @@ pub fn drawCircleAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle:
 
         angle += steplen * 2;
         pdrawRectangle(pos0, pos1, pos2, pos3, colour) catch |err| {
-            if (err == renderer.Error.ObjectOverflow) {
+            if (err == error.ObjectOverflow) {
                 if (prenderer2D.autoflush) {
                     try flushBatch2D();
                     try pdrawRectangle(pos0, pos1, pos2, pos3, colour);
                 } else {
-                    return Error.FailedToDraw;
+                    return error.FailedToDraw;
                 }
             } else return err;
         };
@@ -735,12 +735,12 @@ pub fn drawCircleAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle:
         const pos3 = Vec2f{ .x = center.x, .y = center.y };
         
         pdrawRectangle(pos0, pos1, pos2, pos3, colour) catch |err| {
-            if (err == renderer.Error.ObjectOverflow) {
+            if (err == error.ObjectOverflow) {
                 if (prenderer2D.autoflush) {
                     try flushBatch2D();
                     try pdrawRectangle(pos0, pos1, pos2, pos3, colour);
                 } else {
-                    return Error.FailedToDraw;
+                    return error.FailedToDraw;
                 }
             } else return err;
         };
@@ -750,13 +750,13 @@ pub fn drawCircleAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle:
 /// Draws a circle lines
 /// The segments are lowered for sake of 
 /// making it smaller on the batch
-pub fn drawCircleLines(position: Vec2f, radius: f32, colour: Colour) Error!void {
+pub fn drawCircleLines(position: Vec2f, radius: f32, colour: Colour) !void {
     try drawCircleLinesAdvanced(position, radius, 0, 360, 16, colour);
 }
 
 // Source: https://github.com/raysan5/raylib/blob/f1ed8be5d7e2d966d577a3fd28e53447a398b3b6/src/shapes.c#L298 
 /// Draws a circle lines
-pub fn drawCircleLinesAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle: i32, segments: i32, colour: Colour) Error!void {
+pub fn drawCircleLinesAdvanced(center: Vec2f, radius: f32, startangle: i32, endangle: i32, segments: i32, colour: Colour) !void {
     const SMOOTH_CIRCLE_ERROR_RATE = comptime 0.5;
     
     var iradius = radius;
@@ -829,26 +829,26 @@ pub fn drawCircleLinesAdvanced(center: Vec2f, radius: f32, startangle: i32, enda
 }
 
 /// Draws a rectangle
-pub fn drawRectangle(rect: Rectangle, colour: Colour) Error!void {
+pub fn drawRectangle(rect: Rectangle, colour: Colour) !void {
     const pos0 = Vec2f{ .x = rect.x, .y = rect.y };
     const pos1 = Vec2f{ .x = rect.x + rect.width, .y = rect.y };
     const pos2 = Vec2f{ .x = rect.x + rect.width, .y = rect.y + rect.height };
     const pos3 = Vec2f{ .x = rect.x, .y = rect.y + rect.height };
 
     pdrawRectangle(pos0, pos1, pos2, pos3, colour) catch |err| {
-        if (err == renderer.Error.ObjectOverflow) {
+        if (err == error.ObjectOverflow) {
             if (prenderer2D.autoflush) {
                 try flushBatch2D();
                 try pdrawRectangle(pos0, pos1, pos2, pos3, colour);
             } else {
-                return Error.FailedToDraw;
+                return error.FailedToDraw;
             }
         } else return err;
     };
 }
 
 /// Draws a rectangle lines
-pub fn drawRectangleLines(rect: Rectangle, colour: Colour) Error!void {
+pub fn drawRectangleLines(rect: Rectangle, colour: Colour) !void {
     try drawRectangle(.{ .x = rect.x, .y = rect.y, .width = rect.width, .height = 1 }, colour);
     try drawRectangle(.{ .x = rect.x + rect.width - 1, .y = rect.y + 1, .width = 1, .height = rect.height - 2 }, colour);
     try drawRectangle(.{ .x = rect.x, .y = rect.y + rect.height - 1, .width = rect.width, .height = 1 }, colour);
@@ -856,7 +856,7 @@ pub fn drawRectangleLines(rect: Rectangle, colour: Colour) Error!void {
 }
 
 /// Draws a rectangle rotated(rotation should be provided in radians)
-pub fn drawRectangleRotated(rect: Rectangle, origin: Vec2f, rotation: f32, colour: Colour) Error!void {
+pub fn drawRectangleRotated(rect: Rectangle, origin: Vec2f, rotation: f32, colour: Colour) !void {
     var matrix = ModelMatrix{};
     matrix.translate(rect.x, rect.y, 0);
     matrix.translate(origin.x, origin.y, 0);
@@ -875,38 +875,38 @@ pub fn drawRectangleRotated(rect: Rectangle, origin: Vec2f, rotation: f32, colou
     const pos3 = Vec2f{ .x = rect.x + r3.x, .y = rect.y + r3.y };
 
     pdrawRectangle(pos0, pos1, pos2, pos3, colour) catch |err| {
-        if (err == renderer.Error.ObjectOverflow) {
+        if (err == error.ObjectOverflow) {
             if (prenderer2D.autoflush) {
                 try flushBatch2D();
                 try pdrawRectangle(pos0, pos1, pos2, pos3, colour);
             } else {
-                return Error.FailedToDraw;
+                return error.FailedToDraw;
             }
         } else return err;
     };
 }
 
 /// Draws a texture
-pub fn drawTexture(rect: Rectangle, srcrect: Rectangle, colour: Colour) Error!void {
+pub fn drawTexture(rect: Rectangle, srcrect: Rectangle, colour: Colour) !void {
     const pos0 = Vec2f{ .x = rect.x, .y = rect.y };
     const pos1 = Vec2f{ .x = rect.x + rect.width, .y = rect.y };
     const pos2 = Vec2f{ .x = rect.x + rect.width, .y = rect.y + rect.height };
     const pos3 = Vec2f{ .x = rect.x, .y = rect.y + rect.height };
 
     pdrawTexture(pos0, pos1, pos2, pos3, srcrect, colour) catch |err| {
-        if (err == renderer.Error.ObjectOverflow) {
+        if (err == error.ObjectOverflow) {
             if (prenderer2D.autoflush) {
                 try flushBatch2D();
                 try pdrawTexture(pos0, pos1, pos2, pos3, srcrect, colour);
             } else {
-                return Error.FailedToDraw;
+                return error.FailedToDraw;
             }
         } else return err;
     };
 }
 
 /// Draws a texture(rotation should be provided in radians)
-pub fn drawTextureRotated(rect: Rectangle, srcrect: Rectangle, origin: Vec2f, rotation: f32, colour: Colour) Error!void {
+pub fn drawTextureRotated(rect: Rectangle, srcrect: Rectangle, origin: Vec2f, rotation: f32, colour: Colour) !void {
     var matrix = ModelMatrix{};
     matrix.translate(rect.x, rect.y, 0);
     matrix.translate(origin.x, origin.y, 0);
@@ -925,12 +925,12 @@ pub fn drawTextureRotated(rect: Rectangle, srcrect: Rectangle, origin: Vec2f, ro
     const pos3 = Vec2f{ .x = rect.x + r3.x, .y = rect.y + r3.y };
 
     pdrawTexture(pos0, pos1, pos2, pos3, srcrect, colour) catch |err| {
-        if (err == renderer.Error.ObjectOverflow) {
+        if (err == error.ObjectOverflow) {
             if (prenderer2D.autoflush) {
                 try flushBatch2D();
                 try pdrawTexture(pos0, pos1, pos2, pos3, srcrect, colour);
             } else {
-                return Error.FailedToDraw;
+                return error.FailedToDraw;
             }
         } else return err;
     };
@@ -958,28 +958,28 @@ fn pTextureShaderAttribs() void {
     gl.shaderProgramSetVertexAttribPointer(2, 4, f32, false, stride, @intToPtr(?*const c_void, @byteOffsetOf(Vertex2DTexture, "colour")));
 }
 
-fn pnoTextureSubmitQuadfn(self: *Batch2DQuadNoTexture, vertex: [Batch2DQuadNoTexture.max_vertex_count]Vertex2DNoTexture) renderer.Error!void {
+fn pnoTextureSubmitQuadfn(self: *Batch2DQuadNoTexture, vertex: [Batch2DQuadNoTexture.max_vertex_count]Vertex2DNoTexture) !void {
     try psubmitVerticesQuad(Batch2DQuadNoTexture, self, vertex);
     try psubmitIndiciesQuad(Batch2DQuadNoTexture, self);
 
     self.submission_counter += 1;
 }
 
-fn pTextureSubmitQuadfn(self: *Batch2DQuadTexture, vertex: [Batch2DQuadTexture.max_vertex_count]Vertex2DTexture) renderer.Error!void {
+fn pTextureSubmitQuadfn(self: *Batch2DQuadTexture, vertex: [Batch2DQuadTexture.max_vertex_count]Vertex2DTexture) !void {
     try psubmitVerticesQuad(Batch2DQuadTexture, self, vertex);
     try psubmitIndiciesQuad(Batch2DQuadTexture, self);
 
     self.submission_counter += 1;
 }
 
-fn psubmitVerticesQuad(comptime typ: type, self: *typ, vertex: [typ.max_vertex_count]typ.Vertex) renderer.Error!void {
+fn psubmitVerticesQuad(comptime typ: type, self: *typ, vertex: [typ.max_vertex_count]typ.Vertex) !void {
     try self.submitVertex(self.submission_counter, 0, vertex[0]);
     try self.submitVertex(self.submission_counter, 1, vertex[1]);
     try self.submitVertex(self.submission_counter, 2, vertex[2]);
     try self.submitVertex(self.submission_counter, 3, vertex[3]);
 }
 
-fn psubmitIndiciesQuad(comptime typ: type, self: *typ) renderer.Error!void {
+fn psubmitIndiciesQuad(comptime typ: type, self: *typ) !void {
     if (self.submission_counter == 0) {
         try self.submitIndex(self.submission_counter, 0, 0);
         try self.submitIndex(self.submission_counter, 1, 1);
@@ -1001,11 +1001,11 @@ fn psubmitIndiciesQuad(comptime typ: type, self: *typ) renderer.Error!void {
     }
 }
 
-fn pdrawRectangle(pos0: Vec2f, pos1: Vec2f, pos2: Vec2f, pos3: Vec2f, colour: Colour) Error!void {
-    if (prenderer2D.textured) return Error.InvalidBatch;
+fn pdrawRectangle(pos0: Vec2f, pos1: Vec2f, pos2: Vec2f, pos3: Vec2f, colour: Colour) !void {
+    if (prenderer2D.textured) return error.InvalidBatch;
     switch (prenderer2D.tag) {
         Renderer2DBatchTag.lines => {
-            return Error.InvalidBatch;
+            return error.InvalidBatch;
         },
         else => {},
     }
@@ -1017,11 +1017,11 @@ fn pdrawRectangle(pos0: Vec2f, pos1: Vec2f, pos2: Vec2f, pos3: Vec2f, colour: Co
     });
 }
 
-fn pdrawTexture(pos0: Vec2f, pos1: Vec2f, pos2: Vec2f, pos3: Vec2f, srcrect: Rectangle, colour: Colour) Error!void {
-    if (!prenderer2D.textured) return Error.InvalidBatch;
+fn pdrawTexture(pos0: Vec2f, pos1: Vec2f, pos2: Vec2f, pos3: Vec2f, srcrect: Rectangle, colour: Colour) !void {
+    if (!prenderer2D.textured) return error.InvalidBatch;
     switch (prenderer2D.tag) {
         Renderer2DBatchTag.triangles, Renderer2DBatchTag.lines => {
-            return Error.InvalidBatch;
+            return error.InvalidBatch;
         },
         else => {},
     }

--- a/src/kiragine/sharedtypes.zig
+++ b/src/kiragine/sharedtypes.zig
@@ -47,61 +47,6 @@ pub const Camera2D = cam.Camera2D;
 pub const Colour = renderer.ColourGeneric(f32);
 pub const UColour = renderer.ColourGeneric(u8);
 
-/// Private Error set
-const pError = error{
-    /// Engine is not initialized, initialize it before using the engine
-    EngineIsNotInitialized,
-    /// Engine is initialized, cannot initialize it again
-    EngineIsInitialized,
-    /// Current batch cannot able to do thing you are just about to do
-    InvalidBatch,
-    /// Failes to load texture
-    FailedToLoadTexture,
-    /// Current batch has filled, cannot able to draw anymore
-    FailedToDraw,
-    /// Texture is not available or corrupted
-    InvalidTexture,
-    /// Custom batch already enabled
-    UnableToEnableCustomBatch,
-
-    // Merge input errors
-
-    /// Binding is not available
-    InvalidBinding,
-    /// Binding list has filled, cannot able to bind anymore
-    NoEmptyBinding,
-
-    // Merge kira errors
-
-    /// Check has failed(expression was true)
-    CheckFailed,
-
-    // Merge glfw errors
-
-    /// GLFW failed to initialize, check logs!
-    GLFWFailedToInitialize,
-
-    // Merge renderer errors
-
-    /// OpenGL failes to generate vbo, vao, ebo
-    FailedToGenerateBuffers,
-    /// Object list has been reached it's limits
-    /// and you are trying to write into it
-    ObjectOverflow,
-    /// Vertex list has been reached it's limits
-    /// and you are trying to write into it
-    VertexOverflow,
-    /// Index list has been reached it's limits
-    /// and you are trying to write into it
-    IndexOverflow,
-    /// Submit fn is not initialized
-    /// and you are trying to execute it
-    UnknownSubmitFn,
-};
-
-/// Error set
-pub const Error = pError || input.Error || utils.Error || glfw.Error || renderer.Error;
-
 /// Helper type for using MVP's
 pub const ModelMatrix = struct {
     model: Mat4x4f = Mat4x4f.identity(),
@@ -150,7 +95,7 @@ pub const Texture = struct {
     }
 
     /// Creates a texture from png file
-    pub fn createFromPNG(path: []const u8) Error!Texture {
+    pub fn createFromPNG(path: []const u8) !Texture {
         var result = Texture{};
         result.loadSetup();
         defer gl.textureBind(gl.TextureType.t2D, 0);
@@ -163,7 +108,7 @@ pub const Texture = struct {
 
         if (data == null) {
             gl.texturesDelete(1, @ptrCast([*]u32, &result.id));
-            return Error.FailedToLoadTexture;
+            return error.FailedToLoadTexture;
         }
 
         gl.textureTexImage2D(gl.TextureType.t2D, 0, gl.TextureFormat.rgba8, result.width, result.height, 0, gl.TextureFormat.rgba, u8, data);
@@ -172,7 +117,7 @@ pub const Texture = struct {
     }
 
     /// Creates a texture from png memory
-    pub fn createFromPNGMemory(mem: []const u8) Error!Texture {
+    pub fn createFromPNGMemory(mem: []const u8) !Texture {
         var result = Texture{};
         result.loadSetup();
         defer gl.textureBind(gl.TextureType.t2D, 0);
@@ -185,7 +130,7 @@ pub const Texture = struct {
 
         if (data == null) {
             gl.texturesDelete(1, @ptrCast([*]u32, &result.id));
-            return Error.FailedToLoadTexture;
+            return error.FailedToLoadTexture;
         }
 
         gl.textureTexImage2D(gl.TextureType.t2D, 0, gl.TextureFormat.rgba8, result.width, result.height, 0, gl.TextureFormat.rgba, u8, data);


### PR DESCRIPTION
With the current way that all errors are merged into one big errorset it is not possible to know what errors a function can return, using infered errorsets would allow switching on errors in a much nicer fashion.

For example in current master the following code:
```zig
const t = engine.Texture.createFromPNG("ddd") catch |err| {
	switch (err) {
		
	}
};
```
Complains about the following missing branches:
``` zig
error.EngineIsNotInitialized
error.EngineIsInitialized
error.InvalidBatch
error.FailedToLoadTexture
error.FailedToDraw
error.InvalidTexture
error.UnableToEnableCustomBatch
error.InvalidBinding
error.NoEmptyBinding
error.CheckFailed
error.GLFWFailedToInitialize
error.FailedToGenerateBuffers
error.ObjectOverflow
error.VertexOverflow
error.IndexOverflow
error.UnknownSubmitFn
```

However after applying this change there is only one possible error returned by this function
```zig
error.FailedToLoadTexture
``` 